### PR TITLE
Invert host check in User Provider

### DIFF
--- a/src/main/java/net/trajano/sonar/plugins/reverseproxyauth/ReverseProxyAuthUsersProvider.java
+++ b/src/main/java/net/trajano/sonar/plugins/reverseproxyauth/ReverseProxyAuthUsersProvider.java
@@ -39,7 +39,7 @@ public class ReverseProxyAuthUsersProvider extends ExternalUsersProvider {
     public UserDetails doGetUserDetails(final Context context) {
 
         final UserDetails userDetails = new UserDetails();
-        if (!localHost.equals(context.getRequest().getServerName())) {
+        if (localHost.equals(context.getRequest().getServerName())) {
             final String headerValue = context.getRequest().getHeader(
                     headerName);
             if (headerValue == null || headerValue.trim().isEmpty()) {


### PR DESCRIPTION
This allows user details to be set. Without this, an empty user details is always returned. I don't understand how this works otherwise.
